### PR TITLE
Fix deployment issues with template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY ?= hyc-cp4mcm-team-docker-local.artifactory.swg-devops.com
+REGISTRY ?= PLACEHOLDER_REGISTRY_ADDRESS
 TAG ?= latest
 
 DOCKER_IMAGE := $(REGISTRY)/cp/aiopsedge/java-grpc-connector-template:$(TAG)

--- a/bundle-artifacts/prereqs/kustomization.yaml
+++ b/bundle-artifacts/prereqs/kustomization.yaml
@@ -20,7 +20,7 @@ images:
     newTag: latest
   - name: generic-topology-processor
     newName: cp.icr.io/cp/cp4waiops/generic-topology-processor
-    digest: sha256:16a936ef8e0b67ad7511ae3d1590f1f568a06dba51761e6cfd0a82cb5c60a4aa
+    digest: REPLACE_WITH_DIGEST_FROM_INSTALL
   - name: instana-topology
     newName: cp.icr.io/cp/cp4waiops/instana-topology
-    digest: sha256:ebb68df8e8d2a9e964589e54ea5bf9cbe66c7841a35045dfd01e80ee1cefbc37
+    digest: REPLACE_WITH_DIGEST_FROM_INSTALL

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,10 +8,11 @@ RUN microdnf update && \
     microdnf install -y procps-ng java-11-openjdk tar && \
     microdnf clean all
 
-RUN curl -s -o /tmp/mvn.tar.gz https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz && \
+# Use https://archive.apache.org/dist/maven/maven-3/, which has older versions that some mirrors do not have
+RUN curl -s -o /tmp/mvn.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz && \
     mkdir /tmp/mvn && \
     tar xfz /tmp/mvn.tar.gz -C /tmp/mvn && \
-    mv /tmp/mvn/apache-maven-3.8.6 /usr/local/maven
+    mv /tmp/mvn/apache-maven-3.9.0 /usr/local/maven
 
 ENV PATH="/usr/local/maven/bin:${PATH}"
 ENV MVN_HOME=/usr/local/maven
@@ -24,7 +25,7 @@ COPY src /build/connector/src
 RUN cd /build/connector && rm -r src/main/liberty && mvn install
 
 ## Final image
-FROM icr.io/appcafe/websphere-liberty:22.0.0.9-kernel-java11-openj9-ubi
+FROM --platform=linux/amd64 icr.io/appcafe/websphere-liberty:22.0.0.9-kernel-java11-openj9-ubi
 
 USER 0
 RUN dnf install -y procps-ng && dnf clean all

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ibm.cp4waiops.connectors</groupId>
       <artifactId>connectors-sdk</artifactId>
-      <version>1.4.3</version> <!-- CONNECTOR_SDK_VERSION -->
+      <version>1.4.13</version> <!-- CONNECTOR_SDK_VERSION -->
     </dependency>
     <!-- CloudEvent object and associated builder -->
     <dependency>
@@ -66,11 +66,11 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.3.4</version>
+        <version>3.7.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
For https://github.com/IBM/cp4waiops-connectors-java-template/issues/6 and https://github.com/IBM/cp4waiops-connectors-java-template/issues/5

Tested this with my own image registry. Made sure the java template pod would start as well as the generic topology pod. One of the other instana pods is a dependency pod that doesn't stay up.

<img width="1428" alt="Screenshot 2023-02-09 at 11 35 28 AM" src="https://user-images.githubusercontent.com/7843164/217939326-114eea88-4b73-4e66-ab6c-55d30c31b354.png">
<img width="1438" alt="Screenshot 2023-02-09 at 11 35 17 AM" src="https://user-images.githubusercontent.com/7843164/217939331-f50dee12-52c4-4b9d-82f9-4734bd6e4ca8.png">

Signed-off-by: Steven Hung <sghung@ca.ibm.com>