### PR TITLE
add grpc-bridge property and remove SDK retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ components:
 
 ## Development
 
-First [obtain the sdk](#obtain-the-sdk).
-
 To run the liberty server outside of a docker container, navigate to the top directory and run
 `mvn liberty:run`. Settings can be provided in the `src/main/liberty/config/bootstrap.properties` or
 `src/main/liberty/config/server.xml` file. Be aware that values set there will not be used in the
@@ -61,6 +59,7 @@ grpc-bridge.client-secret="<SECRET>"
 Get the UUID of the `ConnectorConfiguration` instance that is created when you make a connection
 ```
 connector-template.id="<UUID>"
+grpc-bridge.id="<UUID>"
 ```
 
 After running `mvn liberty:run`, your connector will get the configuration from the gRPC server.

--- a/src/main/liberty/config/bootstrap.properties
+++ b/src/main/liberty/config/bootstrap.properties
@@ -13,6 +13,7 @@ grpc-bridge.client-secret="<SECRET>"
 
 # The UUID of the Service Now ConnectorConfiguration
 connector-template.id="<UUID>"
+grpc-bridge.id="<UUID>"
 
 com.ibm.ws.logging.console.format=simple#json
 com.ibm.ws.logging.console.source=message,trace


### PR DESCRIPTION
Updating the connector readme and properties file with the new grpc-bridge id and removal of the manual SDK download