### PR TITLE
Remove trailing space from filename microprofile-config.properties

### DIFF
--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,1 @@
+grpc-bridge.grpc-client-keep-alive-time-seconds=60

--- a/src/main/resources/META-INF/microprofile-config.properties 
+++ b/src/main/resources/META-INF/microprofile-config.properties 
@@ -1,1 +1,0 @@
-grpc-bridge.grpc-client-keep-alive-time-seconds=60


### PR DESCRIPTION
Rename "`microprofile-config.properties `" to "`microprofile-config.properties`"